### PR TITLE
Fix throwing errors when some job data is not available at the moment

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ There is a docker-compose file, which will start:
      - cd to the dir
      - virtualenv --python=/usr/bin/python3 venv3
      - source venv3/bin/activate
-     - pip install "OctoPrint>=1.4.0rc1"
+     - pip install "OctoPrint>=1.4.0"
      - pip install -e .
      - octoprint serve --debug
      - (on mac there could be a hidden "give me a root password" line)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   prometheus:
     image: prom/prometheus:v2.14.0
@@ -6,10 +6,10 @@ services:
       - ./docker/prometheus/:/etc/prometheus/
       - ./docker/prometheus_data:/prometheus
     command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
-      - '--web.console.templates=/usr/share/prometheus/consoles'
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
     ports:
       - 9090:9090
   grafana:
@@ -25,8 +25,8 @@ services:
     env_file:
       - ./docker/grafana/config.monitoring
   octoprint:
-    image: nunofgs/octoprint:1.3.11-debian
+    image: octoprint/octoprint:1.4
     ports:
       - "5000:80"
     volumes:
-      - ./docker/octoprint_data:/data
+      - ./docker/octoprint_data:/root/.octoprint/

--- a/octoprint_prometheus_exporter/__init__.py
+++ b/octoprint_prometheus_exporter/__init__.py
@@ -263,9 +263,12 @@ class PrometheusExporterPlugin(octoprint.plugin.BlueprintPlugin,
 			if self.print_progress_label != '':
 				data = self._printer.get_current_data()
 				#self._logger.info(data)
-				self.print_time_elapsed.labels(self.print_progress_label).set(data['progress']['printTime'])
-				self.print_time_est.labels(self.print_progress_label).set(data['job']['estimatedPrintTime'])
-				self.print_time_left_est.labels(self.print_progress_label).set(data['progress']['printTimeLeft'])
+				if data['progress']['printTime'] is not None:
+					self.print_time_elapsed.labels(self.print_progress_label).set(data['progress']['printTime'])
+				if data['progress']['printTimeLeft'] is not None:
+					self.print_time_left_est.labels(self.print_progress_label).set(data['progress']['printTimeLeft'])
+				if data['job']['estimatedPrintTime'] is not None:
+					self.print_time_est.labels(self.print_progress_label).set(data['job']['estimatedPrintTime'])
 
 		return None  # no change
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_prometheus_exporter"
 plugin_name = "OctoPrint-Prometheus-Exporter"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.5"
+plugin_version = "0.1.6"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
This error was not 100% reproducible, in some cases it happens that OctoPrint doesn't provide all job data needed for metrics.
Easiest fix seems to just handle it with ifs silently.