### PR TITLE
use permissions system for metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Or if you have enabled authentication:
 
 ### Permission system
 
-New in version 0.2.0: by default all users / operators have access to the metrics endpoint. If you want to make metrics accessible to anonymous users (guests) without disabling your enitre authentication system simply add the metrics permission to the guest user group.
+New in version 0.2.0: by default all users / operators have access to the metrics endpoint. If you want to make metrics accessible to anonymous users (guests) without disabling your entire authentication system simply add the metrics permission to the guest user group.
 
 ## Local developement/testing
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Or if you have enabled authentication:
       - targets: ['octoprint:80']
 ```
 
+### Permission system
+
+New in version 0.2.0: by default all users / operators have access to the metrics endpoint. If you want to make metrics accessible to anonymous users (guests) without disabling your enitre authentication system simply add the metrics permission to the guest user group.
+
 ## Local developement/testing
 
 There is a docker-compose file, which will start:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_prometheus_exporter"
 plugin_name = "OctoPrint-Prometheus-Exporter"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.7"
+plugin_version = "0.2.0"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Access to the metrics endpoint can now be managed through the permissions system.

If you want to make metrics accessible to anonymous users (guests) without disabling your entire authentication system simply add the metrics permission to the guest user group.

This should increment the version number from 0.1.7 to 0.2.0.