### PR TITLE
run vcgencmd only on supported systems

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_prometheus_exporter"
 plugin_name = "OctoPrint-Prometheus-Exporter"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.2.0"
+plugin_version = "0.2.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Getting RaspberryPi core temperatures on systems other than RaspberryPi causes error messages. This PR checks if the binary `vcgencmd` is available before running it.

This should increment the version number from 0.2.0 to 0.2.1.