### PR TITLE
Fix version number to silence false software update notification

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_prometheus_exporter"
 plugin_name = "OctoPrint-Prometheus-Exporter"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.2.1"
+plugin_version = "0.2.2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Found this when updating a few of my machines.  I'd still get the notification that I needed to update to 0.2.2 even though I just had.  

Not sure that this is the correct fix since 0.2.2 is already released, but thought I'd share the issue and my current workaround.  

Thanks for the plugin, been using it a couple years now.  