### PR TITLE
Bugfixes for a number of things

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ end_of_line = lf
 charset = utf-8
 insert_final_newline = true
 trim_trailing_whitespace = true
+max_line_length = 120
 
 [**.py]
 indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,10 @@ trim_trailing_whitespace = true
 [**.py]
 indent_style = tab
 
+[*/gcodeparser.py]
+indent_style = space
+indent_size = 4
+
 [**.js]
 indent_style = space
 indent_size = 4

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+extend-ignore = W191
+max-line-length = 120

--- a/octoprint_prometheus_exporter/__init__.py
+++ b/octoprint_prometheus_exporter/__init__.py
@@ -173,7 +173,7 @@ class PrometheusExporterPlugin(octoprint.plugin.BlueprintPlugin,
 
 	##~~ ProgressPlugin mixin
 	def on_print_progress(self, storage, path, progress):
-		self.metrics.print_progress_label = path
+		self.print_progress_label = path
 		self.metrics.print_progress.labels(path).set(progress)
 		pass
 	def	on_slicing_progress(self, slicer, source_location, source_path, destination_location, destination_path, progress):

--- a/octoprint_prometheus_exporter/gcodeparser.py
+++ b/octoprint_prometheus_exporter/gcodeparser.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re
-import sys
 
 # https://community.octoprint.org/t/how-to-determine-filament-extruded/7828
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_prometheus_exporter"
 plugin_name = "OctoPrint-Prometheus-Exporter"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.2.1"
+plugin_version = "0.2.2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
This PR contains a bunch of bugfixes thrown together, let me know if you'd prefer separate PRs for these

- Development stuff
  - Add gcodeparser.py entry to editorconfig
  - Set max_line_length in editorconfig
  - Add .flake8 file to suppress warnings from pylsp

- Print time metric issue
  - Fix wrong attribute being used for print time metrics resulting in missing `octoprint_print_time_*` metrics

- setup.py issue
  - Bump plugin version to 0.2.2 (fixes #38)

- G-code parsing
  - Implement coordinate mode switch detection (`G90`/`G91`/`M82`/`M83`) in gcodeparser
  - Extend `Gcode_parser.process_line` to handle relative moves (fixes #25)
  - Drop unused import of `sys` in gcodeparser
  - Handle `G92` (coordinate reset) in prometheus exporter gcode parser


Screenshot of a graph of a slow spiral vase print (at ~20mm/s)
![image](https://github.com/tg44/OctoPrint-Prometheus-Exporter/assets/88355/09f4e365-9f33-40f0-98c9-beae3d8d59a9)
