### PR TITLE
Add metrics for current coordinates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,6 +17,10 @@ indent_style = tab
 indent_style = space
 indent_size = 4
 
+[*/metrics.py]
+indent_style = space
+indent_size = 4
+
 [**.js]
 indent_style = space
 indent_size = 4

--- a/octoprint_prometheus_exporter/__init__.py
+++ b/octoprint_prometheus_exporter/__init__.py
@@ -131,9 +131,11 @@ class PrometheusExporterPlugin(octoprint.plugin.BlueprintPlugin,
 					self.metrics.extrusion_print.inc(self.parser.extrusion_counter - self.last_extrusion_counter)
 					self.metrics.extrusion_total.inc(self.parser.extrusion_counter - self.last_extrusion_counter)
 					self.last_extrusion_counter = self.parser.extrusion_counter
+				self.metrics.current_e.set(self.parser.e)
 
 				# x_travel_print is modeled as a gauge so we can reset it after every print
 				self.metrics.x_travel_print.set(self.parser.x_travel)
+				self.metrics.current_x.set(self.parser.x)
 
 				if self.parser.x_travel > self.last_x_travel:
 					# x_travel_total is monotonically increasing for the lifetime of the plugin
@@ -142,6 +144,7 @@ class PrometheusExporterPlugin(octoprint.plugin.BlueprintPlugin,
 
 				# y_travel_print is modeled as a gauge so we can reset it after every print
 				self.metrics.y_travel_print.set(self.parser.y_travel)
+				self.metrics.current_y.set(self.parser.y)
 
 				if self.parser.y_travel > self.last_y_travel:
 					# y_travel_total is monotonically increasing for the lifetime of the plugin
@@ -150,6 +153,7 @@ class PrometheusExporterPlugin(octoprint.plugin.BlueprintPlugin,
 
 				# z_travel_print is modeled as a gauge so we can reset it after every print
 				self.metrics.z_travel_print.set(self.parser.z_travel)
+				self.metrics.current_z.set(self.parser.z)
 
 				if self.parser.z_travel > self.last_z_travel:
 					# z_travel_total is monotonically increasing for the lifetime of the plugin

--- a/octoprint_prometheus_exporter/metrics.py
+++ b/octoprint_prometheus_exporter/metrics.py
@@ -82,5 +82,11 @@ class Metrics:
     z_travel_total = Counter('octoprint_z_travel_total', 'Z axis travel total', registry=registry)
     z_travel_print = Gauge('octoprint_z_travel_print', 'Z axis travel in this print', registry=registry)
 
+    # coordinates
+    current_x = Gauge('octoprint_current_x', 'Current X coordinate', registry=registry)
+    current_y = Gauge('octoprint_current_y', 'Current Y coordinate', registry=registry)
+    current_z = Gauge('octoprint_current_z', 'Current Z coordinate', registry=registry)
+    current_e = Gauge('octoprint_current_e', 'Current E coordinate', registry=registry)
+
     def render(self):
         return make_wsgi_app(registry=self.registry)


### PR DESCRIPTION
This PR introduces four new gauge metrics showing the current toolhead position as derived from the gcode parser

 - octoprint_current_x
 - octoprint_current_y
 - octoprint_current_z
 - octoprint_current_e


It also adds an editorconfig entry for metrics.py since that file appears to be indented by spaces instead of tabs
